### PR TITLE
Add more info to `dev-lang/python`

### DIFF
--- a/package.env
+++ b/package.env
@@ -1,4 +1,4 @@
-dev-lang/python # O3 works
+dev-lang/python # O3 works (Ofast causes instrumentation tests to hang/segfault, unless `-fno-finite-math-only` is used as well)
 dev-libs/isl # O3 works
 www-client/ungoogled-chromium # O3 works Compiled with CLang, since GCC was breaking for me. Ofast does compile but the browser is completely broken.
 sys-apps/groff # O3 works


### PR DESCRIPTION
`dev-lang/python` works with `-Ofast` if `-fno-finite-math-only` is used as well.